### PR TITLE
Updated model registry to 0.2.11 version

### DIFF
--- a/extension/model/modelRegistry.js
+++ b/extension/model/modelRegistry.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-unused-vars */
 /* eslint-disable max-lines */
 
-let modelRegistryRootURL = "https://storage.googleapis.com/bergamot-models-sandbox/0.2.10";
+let modelRegistryRootURL = "https://storage.googleapis.com/bergamot-models-sandbox/0.2.11";
 const modelRegistryRootURLTest = "https://example.com/browser/browser/extensions/translations/test/browser";
 
 const modelRegistry = {
@@ -184,9 +184,9 @@ const modelRegistry = {
     model: {
       name: "model.deen.intgemm.alphas.bin",
       size: 17140837,
-      estimatedCompressedSize: 13091214,
+      estimatedCompressedSize: 12995752,
       expectedSha256Hash:
-        "dda44d87ab0d8ad3b3871122fd3ee385f37878183a8b4ec139cd909531ec5009",
+        "1980225d00dc5645491777accff5b3c9d20b92eff67a25135f1cf8fe2ed8fb8f",
     },
   },
   encs: {
@@ -215,24 +215,24 @@ const modelRegistry = {
   ende: {
     vocab: {
       name: "vocab.deen.spm",
-      size: 797501,
-      estimatedCompressedSize: 412505,
+      size: 784269,
+      estimatedCompressedSize: 410171,
       expectedSha256Hash:
-        "bc8f8229933d8294c727f3eab12f6f064e7082b929f2d29494c8a1e619ba174c",
+        "417668f2ed297970febafb5b079a9d5ebc4ed0b3550ac8386d67a90473a09bd7",
     },
     lex: {
       name: "lex.50.50.ende.s2t.bin",
-      size: 3062492,
-      estimatedCompressedSize: 1575385,
+      size: 3943644,
+      estimatedCompressedSize: 2113181,
       expectedSha256Hash:
-        "764797d075f0642c0b079cce6547348d65fe4e92ac69fa6a8605cd8b53dacb3f",
+        "f03eb8245042feb7a5800815b8d0dc215d7a60691632405b65c461d250cedbe6",
     },
     model: {
       name: "model.ende.intgemm.alphas.bin",
-      size: 17140498,
-      estimatedCompressedSize: 13207068,
+      size: 17140835,
+      estimatedCompressedSize: 12768493,
       expectedSha256Hash:
-        "f0946515c6645304f0706fa66a051c3b7b7c507f12d0c850f276c18165a10c14",
+        "b3e980d6602ab0bdfe8d9315cb5fc282a16bb1c8dccf38e70945c584551c4318",
     },
   },
   enes: {


### PR DESCRIPTION
Fixes https://github.com/mozilla/firefox-translations/issues/60

It also fixes a part of the problem in https://github.com/mozilla/firefox-translations/issues/58

Test
1. Download Firefox Nightly (German version)
2. Start extension (latest main branch + this PR applied)
3. Navigate to page: https://andrenatal.com/translations-playground/?lang=pt
4. Infobar correctly displays the page language
5. Click on `Übersetzen`
6. The page is translated to German

Replacing `pt` with `es`, `et`, `en`, `it`, `ru` and `cs` in the link https://andrenatal.com/translations-playground/?lang=pt runs successfully.

Also tested on https://www.bbc.com/portuguese and it works there as well.