### PR TITLE
Change telemetry app id

### DIFF
--- a/extension/model/telemetry/Telemetry.js
+++ b/extension/model/telemetry/Telemetry.js
@@ -67,7 +67,7 @@ class TranslationTelemetry {
 class Telemetry {
 
     constructor(sendPings= false, debug= true, enableLogging = false) {
-        this._telemetryId = "org-mozilla-bergamot";
+        this._telemetryId = "firefox-translations";
         this._sendPings = sendPings;
         this._debug = debug;
         this._enableLogging = enableLogging;


### PR DESCRIPTION
We have to change the telemetry app id based on https://github.com/mozilla/probe-scraper/pull/400. Anyway, it's probably a good idea to not mess data from the legacy extension and the new one. The dashboard should be recreated with the new id though, but I think we'll be able to copy them.