### PR TITLE
Disable telemetry uploading in preferences

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build": "web-ext build -s extension --overwrite-dest  --no-config-discovery -n firefox_translations.xpi",
     "format": "prettier 'extension/*.{js,css}' --tab-width=2 --arrow-parens=always --trailing-comma=es5 --no-bracket-spacing --write",
     "lint:extension": "web-ext lint -s extension",
-    "once": "web-ext run -s extension --verbose --firefox nightly  --no-config-discovery --pref=extensions.experiments.enabled=true --pref=extensions.translations.disabled=false --pref=javascript.options.wasm_simd_wormhole=true",
+    "once": "web-ext run -s extension --verbose --firefox nightly  --no-config-discovery --pref=extensions.experiments.enabled=true --pref=extensions.translations.disabled=false --pref=javascript.options.wasm_simd_wormhole=true --pref=datareporting.healthreport.uploadEnabled=false",
     "package": "npm run build && mv web-ext-artifacts/*.zip addon.xpi",
     "setup-webext": "npm install -g web-ext"
   },


### PR DESCRIPTION
fixes #41 

It disables all firefox telemetry on debugging. I think it's the right thing to do.

To test it with telemetry uploading we can either flip this pref or go to Settings -> Privacy & Security -> Nightly Data Collection and Use -> enable "Allow Nightly to send technical and interaction data to Mozilla"
