### PR TITLE
Improved CI

### DIFF
--- a/.github/workflows/build_main.yml
+++ b/.github/workflows/build_main.yml
@@ -15,6 +15,8 @@ jobs:
         run: npm install
       - name: Run linter
         run: npm run lint:js
+      - name: Build
+        run: npm run build
       - uses: actions/upload-artifact@v2
         with:
           name: firefox_translations

--- a/.github/workflows/build_main.yml
+++ b/.github/workflows/build_main.yml
@@ -17,7 +17,9 @@ jobs:
         run: npm run lint:js
       - name: Build
         run: npm run build
-      - uses: actions/upload-artifact@v2
+      - name: Generate artifacts
+        uses: actions/upload-artifact@v2
         with:
           name: firefox_translations
+          if-no-files-found: error
           path: extension/

--- a/.github/workflows/build_pr.yml
+++ b/.github/workflows/build_pr.yml
@@ -13,6 +13,8 @@ jobs:
         run: npm install
       - name: Run linter
         run: npm run lint:js
+      - name: Build
+        run: npm run build
       - uses: actions/upload-artifact@v2
         with:
           name: firefox_translations

--- a/.github/workflows/build_pr.yml
+++ b/.github/workflows/build_pr.yml
@@ -15,7 +15,9 @@ jobs:
         run: npm run lint:js
       - name: Build
         run: npm run build
-      - uses: actions/upload-artifact@v2
+      - name: Generate artifacts
+        uses: actions/upload-artifact@v2
         with:
           name: firefox_translations
+          if-no-files-found: error
           path: extension/


### PR DESCRIPTION
 - Added `npm run build` step in build "main" and "pr" workflows
     - Helps in catching xpi build errors very early. Otherwise, the build errors are not caught until the end-to-end workflow runs (which takes a lot of time).
 - Error if no file available to create artifacts from