### PR TITLE
Remove question mark from checkboxes labels, add CODEOWNERS for l10n

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+extension/_locales/en_US/*.json @flodolo

--- a/extension/_locales/en_US/messages.json
+++ b/extension/_locales/en_US/messages.json
@@ -69,14 +69,14 @@
     },
     "displayStatisticsMessage": {
       "message": "Display statistics",
-      "description": "Option to show statistics in the infobar (display is intended as a verb)."
+      "description": "Option in menu to show statistics in the infobar (display is intended as a verb)."
     },
     "outboundTranslationsMessage": {
-      "message": "Enable translations of forms?",
-      "description": "Ask the users if they want to enable the translation of forms."
+      "message": "Enable translations of forms",
+      "description": "Checkbox to enable the translation of forms."
     },
     "qualityEstimationMessage": {
-      "message": "Enable quality estimation?",
-      "description":"Ask the users if they want to enable the quality estimation of the translation."
+      "message": "Enable quality estimation",
+      "description":"Checkbox to enable the quality estimation of the translation."
     }
 }


### PR DESCRIPTION
Looking at this picture, I realized that these two strings are checkboxes, and shouldn't have a question mark.

https://user-images.githubusercontent.com/66322306/155132251-010bc7ad-1c70-448e-953a-efd498a165ec.png

This also adds a CODEOWNERS file, to flag me in case of changes. In order for that to work, I need to be added as a contributor to the repository.

Side note on that image: I don't think that design is going to scale very well for long languages, but you'll be able to verify it once we have translations, and it's probably good enough to start.