### PR TITLE
Indicate languages with "Beta" quality

### DIFF
--- a/extension/controller/experiments/TranslationBar/api.js
+++ b/extension/controller/experiments/TranslationBar/api.js
@@ -98,9 +98,9 @@
                 translationNotificationManager = new TranslationNotificationManager(
                   this,
                   modelRegistry,
-                  detectedLanguage
+                  detectedLanguage,
+                  navigatorLanguage
                 );
-                translationNotificationManager.navigatorLanguage = navigatorLanguage;
                 translationNotificationManager.tabId = tabId;
                 translationNotificationManager.bgScriptListenerCallback = bgScriptListenerCallback;
                 translationNotificationManager.notificationBox = notif;

--- a/extension/view/js/TranslationNotificationManager.js
+++ b/extension/view/js/TranslationNotificationManager.js
@@ -6,16 +6,14 @@
 // eslint-disable-next-line no-unused-vars
 class TranslationNotificationManager {
 
-    constructor(api, modelRegistry, detectedLanguage) {
+    constructor(api, modelRegistry, detectedLanguage, navigatorLanguage) {
         this.api = api;
         this.modelRegistry = modelRegistry;
         this.detectedLanguage = detectedLanguage;
+        this._navigatorLanguage = navigatorLanguage;
         this.languageSet = new Set();
+        this.devLanguageSet = new Set();
         this.loadLanguages();
-    }
-
-    set navigatorLanguage(val) {
-        this._navigatorLanguage = val;
     }
 
     get navigatorLanguage() {
@@ -70,6 +68,14 @@ class TranslationNotificationManager {
             const secondLang = languagePair.substring(2,4);
             this.languageSet.add(firstLang);
             this.languageSet.add(secondLang);
+
+            const navLangCode = this.navigatorLanguage.substring(0,2);
+            // all languages become 'dev' because translation is pivoted to 'dev' model en-nav_language
+            const isPivotModelDev = navLangCode !== "en" && this.modelRegistry[`en${navLangCode}`].model.modelType === "dev";
+            if (isPivotModelDev || (this.modelRegistry[languagePair].model.modelType === "dev")) {
+                this.devLanguageSet.add(firstLang);
+                this.devLanguageSet.add(secondLang);
+            }
         }
     }
 

--- a/extension/view/js/translation-notification-fxtranslations.js
+++ b/extension/view/js/translation-notification-fxtranslations.js
@@ -100,7 +100,8 @@ window.MozTranslationNotification = class extends MozElements.Notification {
     const sortByLocalizedName = function(setOfLanguages) {
       const arrayOfLanguages = [...setOfLanguages];
       // eslint-disable-next-line no-undefined
-      const names = Services.intl.getLanguageDisplayNames(undefined, arrayOfLanguages);
+      let names = Services.intl.getLanguageDisplayNames(undefined, arrayOfLanguages);
+
       return arrayOfLanguages
         .map((code, i) => [code, names[i]])
         .sort((a, b) => a[1].localeCompare(b[1]));
@@ -109,7 +110,10 @@ window.MozTranslationNotification = class extends MozElements.Notification {
     const detectedLanguage = this._getAnonElt("detectedLanguage");
     const languagesSupported = sortByLocalizedName(this.translationNotificationManager.languageSet);
 
-    for (const [code, name] of languagesSupported) {
+    for (let [code, name] of languagesSupported) {
+      if (this.translationNotificationManager.devLanguageSet.has(code)) {
+            name += " (Beta)";
+      }
       detectedLanguage.appendItem(name, code);
       this.localizedLanguagesByCode[code] = name;
     }


### PR DESCRIPTION
Marks languages as "Beta" if the model that involves this language is a dev one.
fixes #104 

I believe "Beta" is an international IT word and doesn't require localization, the same as "Firefox". Correct me if I'm wrong.