### PR TITLE
Add metrics for quality estimation

### DIFF
--- a/extension/model/telemetry/Telemetry.js
+++ b/extension/model/telemetry/Telemetry.js
@@ -61,7 +61,9 @@ class Telemetry {
         this._updateUsageTime();
     }
 
-    addQualityEstimation(wordScores, sentScores) {
+    addQualityEstimation(wordScores, sentScores, isSupervised) {
+        this._client.boolean("quality", "is_supervised", isSupervised);
+
         for (const score of wordScores) this._wordScores.push(score);
         for (const score of sentScores) this._sentScores.push(score);
 
@@ -69,16 +71,16 @@ class Telemetry {
         const sentStats = this._calcStats(this._sentScores);
 
         this._client.string(
-    "performance", "translation_quality",
+    "quality", "summary",
             `${wordStats.avg},${wordStats.median},${wordStats.perc90},${sentStats.avg},${sentStats.median},${sentStats.perc90}`
         );
         // glean Quantity metric type supports only positive integers
-        this._client.quantity("performance", "word_quality_avg", Math.round(wordStats.avg*1000));
-        this._client.quantity("performance", "word_quality_median", Math.round(wordStats.median*1000));
-        this._client.quantity("performance", "word_quality_90th", Math.round(wordStats.perc90*1000));
-        this._client.quantity("performance", "sent_quality_avg", Math.round(sentStats.avg*1000));
-        this._client.quantity("performance", "sent_quality_median", Math.round(sentStats.median*1000));
-        this._client.quantity("performance", "sent_quality_90th", Math.round(sentStats.perc90*1000));
+        this._client.quantity("quality", "word_avg", Math.round(wordStats.avg*1000));
+        this._client.quantity("quality", "word_median", Math.round(wordStats.median*1000));
+        this._client.quantity("quality", "word_90th", Math.round(wordStats.perc90*1000));
+        this._client.quantity("quality", "sent_avg", Math.round(sentStats.avg*1000));
+        this._client.quantity("quality", "sent_median", Math.round(sentStats.median*1000));
+        this._client.quantity("quality", "sent_90th", Math.round(sentStats.perc90*1000));
     }
 
     _calcStats(array) {

--- a/extension/model/telemetry/Telemetry.js
+++ b/extension/model/telemetry/Telemetry.js
@@ -13,6 +13,8 @@ class Telemetry {
         this._translationStartTimestamp = null;
         this._startTimestamp = null;
         this._otLenthPerTextArea = new Map();
+        this._wordScores = [];
+        this._sentScores = [];
     }
 
     translationStarted() {
@@ -57,6 +59,36 @@ class Telemetry {
         this._client.quantity("forms", "word_count", wordLengthSum)
         this._client.quantity("forms", "field_count", this._otLenthPerTextArea.size)
         this._updateUsageTime();
+    }
+
+    addQualityEstimation(wordScores, sentScores) {
+        for (const score of wordScores) this._wordScores.push(score);
+        for (const score of sentScores) this._sentScores.push(score);
+
+        const wordStats = this._calcStats(this._wordScores);
+        const sentStats = this._calcStats(this._sentScores);
+
+        this._client.string(
+    "performance", "translation_quality",
+            `${wordStats.avg},${wordStats.median},${wordStats.perc90},${sentStats.avg},${sentStats.median},${sentStats.perc90}`
+        );
+        // glean Quantity metric type supports only positive integers
+        this._client.quantity("performance", "word_quality_avg", Math.round(wordStats.avg*1000));
+        this._client.quantity("performance", "word_quality_median", Math.round(wordStats.median*1000));
+        this._client.quantity("performance", "word_quality_90th", Math.round(wordStats.perc90*1000));
+        this._client.quantity("performance", "sent_quality_avg", Math.round(sentStats.avg*1000));
+        this._client.quantity("performance", "sent_quality_median", Math.round(sentStats.median*1000));
+        this._client.quantity("performance", "sent_quality_90th", Math.round(sentStats.perc90*1000));
+    }
+
+    _calcStats(array) {
+        array.sort();
+        const sum = array.reduce((a, b) => a + b, 0);
+        const avg = (sum / array.length) || 0;
+        const median = array[Math.floor(array.length/2)-1] || 0;
+        const perc90 = array[Math.floor(array.length*0.9)-1] || 0;
+
+        return { avg, median, perc90 }
     }
 
     langPair(from, to) {

--- a/extension/model/telemetry/metrics.yaml
+++ b/extension/model/telemetry/metrics.yaml
@@ -473,10 +473,12 @@ performance:
     send_in_pings:
       - custom
     description: |
-      Quality estimation of translation.
+      Summary of quality estimation of translation.
+      All scores are in range [0,1].
+      <word_avg>,<word_median>,<word_90th>,<sent_avg>,<sent_median>,<sent_90th>
+      Example: "0.5,0.55,0.35,0.6,0.55,0.7"
     bugs:
-      - https://github.com/mozilla-extensions/firefox-translations/issues/42
-      - https://github.com/mozilla/firefox-translations/issues/27
+      - https://github.com/mozilla/firefox-translations/issues/107
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1694813
     data_sensitivity:
@@ -484,7 +486,114 @@ performance:
     notification_emails:
       - anatal-all@mozilla.com
     expires: 2022-08-10
-
+  word_quality_avg:
+    type: quantity
+    unit: points
+    lifetime: ping
+    send_in_pings:
+      - custom
+    description: |
+      Average quality estimation of translation for words
+      multiplied by 1000.
+    bugs:
+      - https://github.com/mozilla/firefox-translations/issues/107
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1694813
+    data_sensitivity:
+      - technical
+    notification_emails:
+      - anatal-all@mozilla.com
+    expires: 2022-08-10
+  word_quality_median:
+    type: quantity
+    unit: points
+    lifetime: ping
+    send_in_pings:
+      - custom
+    description: |
+      Median quality estimation of translation for words
+      multiplied by 1000.
+    bugs:
+      - https://github.com/mozilla/firefox-translations/issues/107
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1694813
+    data_sensitivity:
+      - technical
+    notification_emails:
+      - anatal-all@mozilla.com
+    expires: 2022-08-10
+  word_quality_90th:
+    type: quantity
+    unit: points
+    lifetime: ping
+    send_in_pings:
+      - custom
+    description: |
+      90th percentile of quality estimation of translation for words
+      multiplied by 1000.
+    bugs:
+      - https://github.com/mozilla/firefox-translations/issues/107
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1694813
+    data_sensitivity:
+      - technical
+    notification_emails:
+      - anatal-all@mozilla.com
+    expires: 2022-08-10
+  sent_quality_avg:
+    type: quantity
+    unit: points
+    lifetime: ping
+    send_in_pings:
+      - custom
+    description: |
+      Average quality estimation of translation for sentences
+      multiplied by 1000.
+    bugs:
+      - https://github.com/mozilla/firefox-translations/issues/107
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1694813
+    data_sensitivity:
+      - technical
+    notification_emails:
+      - anatal-all@mozilla.com
+    expires: 2022-08-10
+  sent_quality_median:
+    type: quantity
+    unit: points
+    lifetime: ping
+    send_in_pings:
+      - custom
+    description: |
+      Median quality estimation of translation for sentences
+      multiplied by 1000.
+    bugs:
+      - https://github.com/mozilla/firefox-translations/issues/107
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1694813
+    data_sensitivity:
+      - technical
+    notification_emails:
+      - anatal-all@mozilla.com
+    expires: 2022-08-10
+  sent_quality_90th:
+    type: quantity
+    unit: points
+    lifetime: ping
+    send_in_pings:
+      - custom
+    description: |
+      90th percentile of quality estimation of translation for sentences
+      multiplied by 1000.
+    bugs:
+      - https://github.com/mozilla/firefox-translations/issues/107
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1694813
+    data_sensitivity:
+      - technical
+    notification_emails:
+      - anatal-all@mozilla.com
+    expires: 2022-08-10
 infobar:
   displayed:
     type: event

--- a/extension/model/telemetry/metrics.yaml
+++ b/extension/model/telemetry/metrics.yaml
@@ -467,7 +467,8 @@ performance:
     notification_emails:
       - anatal-all@mozilla.com
     expires: 2022-08-10
-  translation_quality:
+quality:
+  summary:
     type: string
     lifetime: ping
     send_in_pings:
@@ -486,7 +487,7 @@ performance:
     notification_emails:
       - anatal-all@mozilla.com
     expires: 2022-08-10
-  word_quality_avg:
+  word_avg:
     type: quantity
     unit: points
     lifetime: ping
@@ -504,7 +505,7 @@ performance:
     notification_emails:
       - anatal-all@mozilla.com
     expires: 2022-08-10
-  word_quality_median:
+  word_median:
     type: quantity
     unit: points
     lifetime: ping
@@ -522,7 +523,7 @@ performance:
     notification_emails:
       - anatal-all@mozilla.com
     expires: 2022-08-10
-  word_quality_90th:
+  word_90th:
     type: quantity
     unit: points
     lifetime: ping
@@ -540,7 +541,7 @@ performance:
     notification_emails:
       - anatal-all@mozilla.com
     expires: 2022-08-10
-  sent_quality_avg:
+  sent_avg:
     type: quantity
     unit: points
     lifetime: ping
@@ -558,7 +559,7 @@ performance:
     notification_emails:
       - anatal-all@mozilla.com
     expires: 2022-08-10
-  sent_quality_median:
+  sent_median:
     type: quantity
     unit: points
     lifetime: ping
@@ -576,7 +577,7 @@ performance:
     notification_emails:
       - anatal-all@mozilla.com
     expires: 2022-08-10
-  sent_quality_90th:
+  sent_90th:
     type: quantity
     unit: points
     lifetime: ping
@@ -585,6 +586,22 @@ performance:
     description: |
       90th percentile of quality estimation of translation for sentences
       multiplied by 1000.
+    bugs:
+      - https://github.com/mozilla/firefox-translations/issues/107
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1694813
+    data_sensitivity:
+      - technical
+    notification_emails:
+      - anatal-all@mozilla.com
+    expires: 2022-08-10
+  is_supervised:
+    type: boolean
+    lifetime: ping
+    send_in_pings:
+      - custom
+    description: |
+      Indicates whether a supervised model was used for quality estimation.
     bugs:
       - https://github.com/mozilla/firefox-translations/issues/107
     data_reviews:

--- a/extension/model/telemetry/schema.js
+++ b/extension/model/telemetry/schema.js
@@ -18,12 +18,6 @@ const telemetrySchema = {
                     "custom"
                 ]
             },
-            "firefox_client_id": {
-                "type": "string",
-                "send_in_pings": [
-                    "custom"
-                ]
-            },
             "extension_version": {
                 "type": "string",
                 "send_in_pings": [
@@ -166,6 +160,42 @@ const telemetrySchema = {
             },
             "translation_quality": {
                 "type": "string",
+                "send_in_pings": [
+                    "custom"
+                ]
+            },
+            "word_quality_avg": {
+                "type": "quantity",
+                "send_in_pings": [
+                    "custom"
+                ]
+            },
+            "word_quality_median": {
+                "type": "quantity",
+                "send_in_pings": [
+                    "custom"
+                ]
+            },
+            "word_quality_90th": {
+                "type": "quantity",
+                "send_in_pings": [
+                    "custom"
+                ]
+            },
+            "sent_quality_avg": {
+                "type": "quantity",
+                "send_in_pings": [
+                    "custom"
+                ]
+            },
+            "sent_quality_median": {
+                "type": "quantity",
+                "send_in_pings": [
+                    "custom"
+                ]
+            },
+            "sent_quality_90th": {
+                "type": "quantity",
                 "send_in_pings": [
                     "custom"
                 ]

--- a/extension/model/telemetry/schema.js
+++ b/extension/model/telemetry/schema.js
@@ -157,45 +157,53 @@ const telemetrySchema = {
                 "send_in_pings": [
                     "custom"
                 ]
-            },
-            "translation_quality": {
+            }
+        },
+        "quality": {
+            "summary": {
                 "type": "string",
                 "send_in_pings": [
                     "custom"
                 ]
             },
-            "word_quality_avg": {
+            "word_avg": {
                 "type": "quantity",
                 "send_in_pings": [
                     "custom"
                 ]
             },
-            "word_quality_median": {
+            "word_median": {
                 "type": "quantity",
                 "send_in_pings": [
                     "custom"
                 ]
             },
-            "word_quality_90th": {
+            "word_90th": {
                 "type": "quantity",
                 "send_in_pings": [
                     "custom"
                 ]
             },
-            "sent_quality_avg": {
+            "sent_avg": {
                 "type": "quantity",
                 "send_in_pings": [
                     "custom"
                 ]
             },
-            "sent_quality_median": {
+            "sent_median": {
                 "type": "quantity",
                 "send_in_pings": [
                     "custom"
                 ]
             },
-            "sent_quality_90th": {
+            "sent_90th": {
                 "type": "quantity",
+                "send_in_pings": [
+                    "custom"
+                ]
+            },
+            "is_supervised": {
+                "type": "boolean",
                 "send_in_pings": [
                     "custom"
                 ]


### PR DESCRIPTION
Metrics are added according to the proposal in #107 

The next step is to implement collection of metrics that includes:
- extracting scores from html attributes somewhere
- pass word and sentence scores to mediator using messaging
- call telemetry.addQualityEstimation ( it can be called many times, for every translation batch)