### PR TITLE
Collect quality estimation metrics

### DIFF
--- a/extension/mediator.js
+++ b/extension/mediator.js
@@ -207,6 +207,9 @@ class Mediator {
             case "onFormsEvent":
                 this.telemetry.formsEvent(message.payload);
                 break;
+            case "reportQeMetrics":
+                this.telemetry.addQualityEstimation(message.payload.wordScores, message.payload.sentScores, false);
+                break;
             case "domMutation":
 
                 if (this.outboundTranslation) {

--- a/extension/model/telemetry/Metrics.js
+++ b/extension/model/telemetry/Metrics.js
@@ -70,6 +70,9 @@ class Metrics {
         if (typeof val !== "number") {
             throw new Error(`Telemetry: Quantity ${category}.${name} must be a number, value: ${val}`)
         }
+        if (val < 0) {
+            throw new Error(`Telemetry: Quantity ${category}.${name} must be non-negative, value: ${val}`)
+        }
         for (const pingName of this._getPings(category, name, "quantity")) {
             let ping = this._build_ping(pingName);
             if (!("quantity" in ping.metrics)) {

--- a/extension/model/telemetry/Telemetry.js
+++ b/extension/model/telemetry/Telemetry.js
@@ -64,8 +64,9 @@ class Telemetry {
     addQualityEstimation(wordScores, sentScores, isSupervised) {
         this._client.boolean("quality", "is_supervised", isSupervised);
 
-        for (const score of wordScores) this._wordScores.push(score);
-        for (const score of sentScores) this._sentScores.push(score);
+        // scores are log probabilities, convert back to probabilities
+        for (const score of wordScores) this._wordScores.push(Math.exp(score));
+        for (const score of sentScores) this._sentScores.push(Math.exp(score));
 
         const wordStats = this._calcStats(this._wordScores);
         const sentStats = this._calcStats(this._sentScores);

--- a/extension/model/telemetry/metrics.yaml
+++ b/extension/model/telemetry/metrics.yaml
@@ -779,6 +779,54 @@ infobar:
     notification_emails:
       - anatal-all@mozilla.com
     expires: 2022-08-10
+  qe_checked:
+    type: event
+    lifetime: ping
+    send_in_pings:
+      - custom
+    description: |
+      User accepts quality estimation by checking the checkbox.
+    bugs:
+      - https://github.com/mozilla/firefox-translations/issues/107
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1694813
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - anatal-all@mozilla.com
+    expires: 2022-08-10
+  qe_unchecked:
+    type: event
+    lifetime: ping
+    send_in_pings:
+      - custom
+    description: |
+      User disables quality estimation by unchecking the checkbox.
+    bugs:
+      - https://github.com/mozilla/firefox-translations/issues/107
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1694813
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - anatal-all@mozilla.com
+    expires: 2022-08-10
+  qe_enabled:
+    type: boolean
+    lifetime: ping
+    send_in_pings:
+      - custom
+    description: |
+      Quality estimation is enabled.
+    bugs:
+      - https://github.com/mozilla/firefox-translations/issues/107
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1694813
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - anatal-all@mozilla.com
+    expires: 2022-08-10
 
 service:
   not_supported:

--- a/extension/model/telemetry/schema.js
+++ b/extension/model/telemetry/schema.js
@@ -269,6 +269,24 @@ const telemetrySchema = {
                 "send_in_pings": [
                     "custom"
                 ]
+            },
+            "qe_checked": {
+                "type": "event",
+                "send_in_pings": [
+                    "custom"
+                ]
+            },
+            "qe_unchecked": {
+                "type": "event",
+                "send_in_pings": [
+                    "custom"
+                ]
+            },
+            "qe_enabled": {
+                "type": "boolean",
+                "send_in_pings": [
+                    "custom"
+                ]
             }
         },
         "service": {

--- a/extension/view/js/InPageTranslation.js
+++ b/extension/view/js/InPageTranslation.js
@@ -575,8 +575,28 @@ class InPageTranslation {
         };
 
         this.updateMap.forEach(updateElement);
+        this.reportQualityEstimation(this.updateMap.keys());
         this.updateMap.clear();
         this.updateTimeout = null;
+    }
+
+    reportQualityEstimation(nodes) {
+        let wordScores = new Map();
+        let sentScores = new Map();
+        for (let node of nodes) {
+            const nodeIterator = document.createTreeWalker(node, NodeFilter.SHOW_ELEMENT);
+            let currentNode = nodeIterator.currentNode;
+            while (currentNode) {
+                if (currentNode.hasAttribute("x-bergamot-word-score")) {
+                    wordScores.set(currentNode, parseFloat(currentNode.getAttribute("x-bergamot-word-score")));
+                }
+                if (currentNode.hasAttribute("x-bergamot-sentence-score")) {
+                    sentScores.set(currentNode, parseFloat(currentNode.getAttribute("x-bergamot-sentence-score")));
+                }
+                currentNode = nodeIterator.nextNode();
+            }
+        }
+        this.notifyMediator("reportQeMetrics", { wordScores: Array.from(wordScores.values()), sentScores: Array.from(sentScores.values()) });
     }
 
     enqueueElement(translationMessage) {

--- a/extension/view/js/translation-notification-fxtranslations.js
+++ b/extension/view/js/translation-notification-fxtranslations.js
@@ -22,7 +22,7 @@ window.MozTranslationNotification = class extends MozElements.Notification {
             <label value="&translation.translateThisPage.label;"/>
             <button class="notification-button primary" label="&translation.translate.button;" anonid="translate" oncommand="this.closest('notification').translate();"/>
             <checkbox anonid="outboundtranslations-check" label="" style="padding-left:5px" oncommand="this.closest('notification').onOutboundClick();" />
-            <checkbox anonid="qualityestimations-check" label="" style="padding-left:5px"/>
+            <checkbox anonid="qualityestimations-check" label="" style="padding-left:5px" oncommand="this.closest('notification').onQeClick();"/>
           </hbox>
           <vbox class="translating-box" pack="center">
             <hbox>
@@ -155,6 +155,16 @@ window.MozTranslationNotification = class extends MozElements.Notification {
       this.translationNotificationManager.reportInfobarEvent("outbound_checked");
     } else {
       this.translationNotificationManager.reportInfobarEvent("outbound_unchecked");
+    }
+  }
+
+  onQeClick() {
+    // eslint-disable-next-line no-warning-comments
+    // todo: report boolean qe_enabled after iframe support is merged
+    if (this._getAnonElt("qualityestimations-check").checked) {
+      this.translationNotificationManager.reportInfobarEvent("qe_checked");
+    } else {
+      this.translationNotificationManager.reportInfobarEvent("qe_unchecked");
     }
   }
 


### PR DESCRIPTION
- log probabilities are converted back to regular probabilities because they are easier to interpret and glean "quantity" supports only non-negative numbers
- it's better to merge #148  first