### PR TITLE
Improve the displaying of the translaton infobar

### DIFF
--- a/extension/controller/backgroundScript.js
+++ b/extension/controller/backgroundScript.js
@@ -68,10 +68,10 @@ const messageListener = async function(message, sender) {
              * with the tabId to the caller
              */
             listeneronUpdatedLoad = (tabId, changeInfo, tab) => {
-                if ((tabId === sender.tab.id || tab.url === sender.tab.url) && changeInfo.status === "complete") {
+                if (tab.id === sender.tab.id || tab.url === sender.tab.url) {
                     browser.tabs.onUpdated.removeListener(listeneronUpdatedLoad);
                     browser.webNavigation.onCompleted.removeListener(webNavigationCompletedLoad);
-                    console.log("browser.tabs.onUpdated.addListener => notifying browser to display the infobar: ", changeInfo.status, tabId, sender.tab.id, tab.url)
+                    console.log("browser.tabs.onUpdated.addListener => notifying browser to display the infobar: ", changeInfo.status, tab.id, sender.tab.id, tab.url)
 
                     /*
                      * some specific race condition in the tab messaging API
@@ -80,8 +80,19 @@ const messageListener = async function(message, sender) {
                      */
                     setTimeout(() => {
                         browser.tabs.sendMessage(
-                            tabId,
-                            { command: "responseMonitorTabLoad", tabId }
+                            tab.id,
+                            { command: "responseMonitorTabLoad", tabId: tab.id }
+                        );
+                    } ,250);
+                } else if (tab.id !== sender.tab.id) {
+                    browser.tabs.onUpdated.removeListener(listeneronUpdatedLoad);
+                    browser.webNavigation.onCompleted.removeListener(webNavigationCompletedLoad);
+                    console.log("browser.tabs.onUpdated.addListener => notifying browser to display the infobar:  tab.id !== sender.tab.id", changeInfo.status, tab.id, sender.tab.id, tab.url)
+
+                    setTimeout(() => {
+                        browser.tabs.sendMessage(
+                            sender.tab.id,
+                            { command: "responseMonitorTabLoad", tabId: sender.tab.id }
                         );
                     } ,250);
                 }

--- a/extension/controller/backgroundScript.js
+++ b/extension/controller/backgroundScript.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 /* global LanguageDetection, browser, PingSender, BERGAMOT_VERSION_FULL, Telemetry, loadFastText, FastText */
 
 /*


### PR DESCRIPTION
Fixes #145 

@eu9ene Please test this and let me know if you still can reproduce situations when the infobar is not displayed, but please, test with the xpi instead of web-ext. I remember from conversations with @rpl that web-ext sometimes introduces race conditions. 

I found some cases, when pasting the url directly to the urlbar very quickly after pressing the + button to create a new tab, that `tabs.onUpdated` neither `webNavigation.onCompleted` are triggered, but after switching between tabs, it would. So it's a very non-deterministic behavior.  

Also, I have a suspicion that this behavior does not happen when using the xpi, otherwise I believe @acornestean would have caught that before. @acornestean, had you find cases when you browsed to a page and the infobar wasn't displayed while it should?