### PR TITLE
Fix e2e tests

### DIFF
--- a/extension/view/js/OutboundTranslation.js
+++ b/extension/view/js/OutboundTranslation.js
@@ -206,7 +206,7 @@ class OutboundTranslation {
 
   updateselectedTextArea(content) {
     var nativeSetterTextarea = Reflect.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, "value").set;
-    Reflect.apply(nativeSetterTextarea, this.selectedTextArea, content);
+    Reflect.apply(nativeSetterTextarea, this.selectedTextArea, [content]);
     const nativeEvent = new Event("input", { bubbles: true });
     this.selectedTextArea.dispatchEvent(nativeEvent);
     this.selectedTextArea.scrollTop = this.selectedTextArea.scrollHeight;


### PR DESCRIPTION
Correct usage of Reflect.apply method that was introduced in https://github.com/mozilla/firefox-translations/pull/188:
 - 3rd argument should be a list:
   https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Reflect/apply

 - This should fix end to end test (as per the [failure log](https://github.com/mozilla/firefox-translations/runs/5728463978?check_suite_focus=true#step:6:482))