### PR TITLE
Remove the entire onload event handlers from monitorTabLoad

### DIFF
--- a/extension/controller/backgroundScript.js
+++ b/extension/controller/backgroundScript.js
@@ -64,58 +64,10 @@ const messageListener = async function(message, sender) {
             break;
         case "monitorTabLoad":
 
-            /*
-             * wait until the page within the tab is loaded, and then return
-             * with the tabId to the caller
-             */
-            listeneronUpdatedLoad = (tabId, changeInfo, tab) => {
-                if (tab.id === sender.tab.id || tab.url === sender.tab.url) {
-                    browser.tabs.onUpdated.removeListener(listeneronUpdatedLoad);
-                    browser.webNavigation.onCompleted.removeListener(webNavigationCompletedLoad);
-                    console.log("browser.tabs.onUpdated.addListener => notifying browser to display the infobar: ", changeInfo.status, tab.id, sender.tab.id, tab.url)
-
-                    /*
-                     * some specific race condition in the tab messaging API
-                     * demands that we wait before sending the message, hence the
-                     * setTimeout
-                     */
-                    setTimeout(() => {
-                        browser.tabs.sendMessage(
-                            tab.id,
-                            { command: "responseMonitorTabLoad", tabId: tab.id }
-                        );
-                    } ,250);
-                } else if (tab.id !== sender.tab.id) {
-                    browser.tabs.onUpdated.removeListener(listeneronUpdatedLoad);
-                    browser.webNavigation.onCompleted.removeListener(webNavigationCompletedLoad);
-                    console.log("browser.tabs.onUpdated.addListener => notifying browser to display the infobar:  tab.id !== sender.tab.id", changeInfo.status, tab.id, sender.tab.id, tab.url)
-
-                    setTimeout(() => {
-                        browser.tabs.sendMessage(
-                            sender.tab.id,
-                            { command: "responseMonitorTabLoad", tabId: sender.tab.id }
-
-                        );
-                    } ,250);
-                }
-            };
-
-            webNavigationCompletedLoad = details => {
-                if (details.tabId === sender.tab.id) {
-                    browser.webNavigation.onCompleted.removeListener(webNavigationCompletedLoad);
-                    browser.tabs.onUpdated.removeListener(listeneronUpdatedLoad);
-                    console.log("webNavigation.onCompleted => notifying browser to display the infobar")
-                    setTimeout(() => {
-                        browser.tabs.sendMessage(
-                            details.tabId ,
-                            { command: "responseMonitorTabLoad", tabId: details.tabId }
-                        );
-                    } ,250);
-                }
-            };
-
-            browser.webNavigation.onCompleted.addListener(webNavigationCompletedLoad);
-            browser.tabs.onUpdated.addListener(listeneronUpdatedLoad);
+            browser.tabs.sendMessage(
+                                 sender.tab.id,
+                                 { command: "responseMonitorTabLoad", tabId: sender.tab.id }
+                                 );
 
             break;
         case "displayTranslationBar":

--- a/extension/controller/backgroundScript.js
+++ b/extension/controller/backgroundScript.js
@@ -37,8 +37,7 @@ const getTelemetry = tabId => {
 
 // eslint-disable-next-line max-lines-per-function
 const messageListener = async function(message, sender) {
-    let listeneronUpdatedLoad = null;
-    let webNavigationCompletedLoad = null;
+
     switch (message.command) {
         case "detectPageLanguage":
             if (!modelFastText) break;

--- a/extension/controller/languageDetection/LanguageDetection.js
+++ b/extension/controller/languageDetection/LanguageDetection.js
@@ -14,12 +14,6 @@ class LanguageDetection {
         this.wordsToDetect = null;
     }
 
-    /*
-     * extracts the page's first 100 words in order to be used by the language
-     * detection module. This heuristic should be revisited in the future, to
-     * something like searching for the elements in the middle of the page
-     * instead of the top
-     */
     extractPageContent() {
         this.wordsToDetect = document.body.innerText;
     }

--- a/scripts/tests/browser_translation_test.js
+++ b/scripts/tests/browser_translation_test.js
@@ -24,14 +24,6 @@ add_task(async function testTranslationBarDisplayed() {
     `${baseURL }browser_translation_test.html`
   );
 
-  /*
-   * the infobar is not triggered first time the page is loaded due a race condition
-   * so we need to reload the tab in order to have it summoned.
-   * It will be fixed on
-   * https://github.com/mozilla/firefox-translations/issues/145
-   */
-  gBrowser.reloadTab(tab);
-
   // wait for the translation bar to be displayed.
   let notification = await TestUtils.waitForCondition(() => gBrowser
       .getNotificationBox()

--- a/scripts/tests/browser_translation_test.js
+++ b/scripts/tests/browser_translation_test.js
@@ -69,7 +69,7 @@ add_task(async function testTranslationBarDisplayed() {
        */
        document.getElementById("mainTextarea").focus();
        document.getElementById("OTapp").querySelectorAll("textarea")[0].value = "Hello World";
-       document.getElementById("OTapp").querySelectorAll("textarea")[0].dispatchEvent(new content.KeyboardEvent('keydown', {'key': 'Enter'}));
+       document.getElementById("OTapp").querySelectorAll("textarea")[0].dispatchEvent(new content.KeyboardEvent("keydown", { "key": "Enter" }));
        await new Promise(resolve => content.setTimeout(resolve, 5000));
 
        is(


### PR DESCRIPTION
fixes #145 

It turns out that we don't need to listen to all onload events since the content scripts are already injected after onLoad:

see https://github.com/mozilla/firefox-translations/blob/main/extension/manifest.json#L58

and https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/extensionTypes/RunAt and https://developer.chrome.com/docs/extensions/mv3/content_scripts/#run_time

That's why the event wasn't triggered all the time.