### PR TITLE
Do not translate the title if quality estimation is selected.

### DIFF
--- a/extension/view/js/InPageTranslation.js
+++ b/extension/view/js/InPageTranslation.js
@@ -157,7 +157,7 @@ class InPageTranslation {
         this.language = language;
 
         const pageTitle = document.getElementsByTagName("title")[0];
-        if (pageTitle) {
+        if (pageTitle && !this.withQualityEstimation) {
             this.queueTranslation(pageTitle);
         }
         this.startTreeWalker(document.body);


### PR DESCRIPTION
fixes #215 

I prefer to skip the title completely if QE is enabled instead of adding many conditional tests all over the class just for that.