### PR TITLE
Auto-translate as browse.

### DIFF
--- a/extension/controller/backgroundScript.js
+++ b/extension/controller/backgroundScript.js
@@ -318,7 +318,6 @@ const messageListener = function(message, sender) {
            * so that when there's a navigation in this tab, site and samelanguage
            * we should automatically start the translation
            */
-          const tab = await browser.tabs.get(message.tabId);
           translateAsBrowseMap.set(message.tabId, {
             translatingAsBrowse: message.translatingAsBrowse
           });

--- a/extension/controller/backgroundScript.js
+++ b/extension/controller/backgroundScript.js
@@ -394,3 +394,8 @@ browser.pageAction.onClicked.addListener(tab => {
           }
     });
 });
+
+// here we remove the closed tabs from translateAsBrowseMap
+browser.tabs.onRemoved.addListener(tabId => {
+  translateAsBrowseMap.delete(tabId);
+});

--- a/extension/controller/experiments/TranslationBar/api.js
+++ b/extension/controller/experiments/TranslationBar/api.js
@@ -44,7 +44,7 @@
       return {
         experiments: {
           translationbar: {
-            show: function show(tabId, detectedLanguage, navigatorLanguage, localizedLabels, pageActionRequest, infobarSettings) {
+            show: function show(tabId, detectedLanguage, navigatorLanguage, localizedLabels, pageActionRequest, infobarSettings, autoTranslate) {
               try {
 
                 const { tabManager } = context.extension;
@@ -111,6 +111,8 @@
                 translationNotificationManager.logoIcon = context.extension.getURL("/view/icons/translation.16x16.png",)
                 translationNotificationManager.localizedLabels = localizedLabels;
                 translationNotificationManager.infobarSettings = infobarSettings;
+                translationNotificationManager.autoTranslate = autoTranslate;
+
                 notif.init(translationNotificationManager);
                 translationNotificationManagers.set(tabId, translationNotificationManager);
               } catch (error) {

--- a/extension/controller/experiments/TranslationBar/schema.json
+++ b/extension/controller/experiments/TranslationBar/schema.json
@@ -37,6 +37,11 @@
               "name": "infobarSettings",
               "type": "any",
               "description": "persisted settings for the infobar"
+            },
+            {
+              "name": "autoTranslate",
+              "type": "any",
+              "description": "determines if the auto translate is set"
             }
           ]
         },

--- a/extension/view/js/TranslationNotificationManager.js
+++ b/extension/view/js/TranslationNotificationManager.js
@@ -14,6 +14,7 @@ class TranslationNotificationManager {
         this.languageSet = new Set();
         this.devLanguageSet = new Set();
         this.storage = null;
+        this.autoTranslate = false;
         this.loadLanguages();
     }
 
@@ -140,7 +141,16 @@ class TranslationNotificationManager {
         /*
          * informs the bgscript to persist settings on storage
          */
-        const message = { command: "setStorage", payload: { [key]: value } };
+        const message = { command: "setStorage", payload: { [key]: value } }
+        this.bgScriptListenerCallback(message);
+    }
+
+    translateAsBrowse() {
+        const message = {
+            command: "translateAsBrowse",
+            tabId: this.tabId,
+            translatingAsBrowse: this.autoTranslate
+        }
         this.bgScriptListenerCallback(message);
     }
 }

--- a/extension/view/js/translation-notification-fxtranslations.js
+++ b/extension/view/js/translation-notification-fxtranslations.js
@@ -25,13 +25,14 @@ window.MozTranslationNotification = class extends MozElements.Notification {
             <checkbox anonid="qualityestimations-check" label="" style="padding-left:5px" oncommand="this.closest('notification').onQeClick();"/>
           </hbox>
           <vbox class="translating-box" pack="center">
-            <hbox>
+            <hbox class="translate-offer-box" align="center">
               <label value="&translation.translatingContent.label;" style="display:none"/>
-              <label anonid="progress-label" value="" style="padding-left:5px"/>     
+              <label anonid="progress-label" value="" style="padding-left:5px;"/>
+              <button class="notification-button primary" label="" anonid="translateAsBrowse" oncommand="this.closest('notification').translateAsBrowse();"/>
             </hbox>
           </vbox>
         </deck>
-        <spacer flex="1"/>        
+        <spacer flex="1"/>
         <button class="notification-button" label="" anonid="survey" oncommand="this.closest('notification').onSurveyClick();"/>
         <button type="menu" class="notification-button" anonid="options" label="&translation.options.menu;">
           <menupopup class="translation-menupopup" onpopupshowing="this.closest('notification').optionsShowing();">
@@ -97,6 +98,8 @@ window.MozTranslationNotification = class extends MozElements.Notification {
     this._getAnonElt("survey").setAttribute("label", translationNotificationManager.localizedLabels.surveyMessage);
     this._getAnonElt("outboundtranslations-check").checked = translationNotificationManager.infobarSettings.outboundtranslations["outboundtranslations-check"];
     this._getAnonElt("qualityestimations-check").checked = translationNotificationManager.infobarSettings.qualityestimations["qualityestimations-check"];
+    this._getAnonElt("translateAsBrowse").setAttribute("label", translationNotificationManager.localizedLabels.translateAsBrowseOn);
+
     this.translationNotificationManager = translationNotificationManager;
     this.localizedLanguagesByCode = {};
 
@@ -143,6 +146,13 @@ window.MozTranslationNotification = class extends MozElements.Notification {
         "boolean", "qe_enabled",
             this._getAnonElt("qualityestimations-check").checked === true
         );
+    if (translationNotificationManager.autoTranslate) {
+      this._getAnonElt("translateAsBrowse").setAttribute(
+        "label",
+        translationNotificationManager.localizedLabels.translateAsBrowseOff,
+      );
+      this.translate();
+    }
   }
 
   _getAnonElt(anonId) {
@@ -199,6 +209,18 @@ window.MozTranslationNotification = class extends MozElements.Notification {
       this.translationNotificationManager.reportInfobarMetric("event","qe_unchecked");
       this.translationNotificationManager.reportInfobarMetric("boolean", "qe_enabled", false);
     }
+  }
+
+  translateAsBrowse() {
+    this.translationNotificationManager.autoTranslate =
+      !this.translationNotificationManager.autoTranslate
+    this._getAnonElt("translateAsBrowse").setAttribute(
+      "label",
+      this.translationNotificationManager.autoTranslate
+      ? this.translationNotificationManager.localizedLabels.translateAsBrowseOff
+      : this.translationNotificationManager.localizedLabels.translateAsBrowseOn
+    );
+    this.translationNotificationManager.translateAsBrowse();
   }
 
   onSurveyClick() {

--- a/extension/view/js/translation-notification-fxtranslations.js
+++ b/extension/view/js/translation-notification-fxtranslations.js
@@ -28,7 +28,7 @@ window.MozTranslationNotification = class extends MozElements.Notification {
             <hbox class="translate-offer-box" align="center">
               <label value="&translation.translatingContent.label;" style="display:none"/>
               <label anonid="progress-label" value="" style="padding-left:5px;"/>
-              <button class="notification-button primary" label="" anonid="translateAsBrowse" oncommand="this.closest('notification').translateAsBrowse();"/>
+              <button class="notification-button" label="" anonid="translateAsBrowse" oncommand="this.closest('notification').translateAsBrowse();"/>
             </hbox>
           </vbox>
         </deck>


### PR DESCRIPTION
fixes #17 

I implemented always translate the tab though, which I found more useful than always translating a site and a language within that tab.

Blocked by: https://github.com/mozilla-l10n/firefox-translations-l10n/pull/7