### PR TITLE
Fetch bergamot translator engine artifacts from GCP instead of Github

### DIFF
--- a/extension/model/engineRegistry.js
+++ b/extension/model/engineRegistry.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-unused-vars */
 
-let engineRegistryRootURL = "https://github.com/mozilla/bergamot-translator/releases/download/v0.4.3/";
+let engineRegistryRootURL = `https://storage.googleapis.com/bergamot-models-sandbox/wasm/0.4.3/`;
 const engineRegistryRootURLTest = "https://example.com/browser/browser/extensions/translations/test/browser/";
 
 const engineRegistryShared = {


### PR DESCRIPTION
Fixes https://github.com/mozilla/firefox-translations/issues/131