### PR TITLE
Replaces unsafe use of innerHTML and appendChild

### DIFF
--- a/extension/view/js/InPageTranslation.js
+++ b/extension/view/js/InPageTranslation.js
@@ -527,8 +527,13 @@ class InPageTranslation {
             // console.groupCollapsed(computePath(node));
             node.setAttribute("x-bergamot-translated", "");
 
-            const scratch = node.cloneNode(false); // shallow clone of parent node
-            scratch.innerHTML = translatedHTML;
+            /*
+             * create a scratch (a DocumentFragment) from translated html that will be
+             * used to populate the live tree with the translated content
+             */
+            const nonLiveDomContainer = document.createElement("template");
+            nonLiveDomContainer.innerHTML = translatedHTML;
+            const scratch = nonLiveDomContainer.content;
 
             const originalHTML = node.innerHTML;
 
@@ -584,13 +589,29 @@ class InPageTranslation {
 
                         if (!counterpart) {
 
+                            const hasOnlyQEAttributes = node => {
+                                const allowed = new Set([
+                                    "x-bergamot-sentence-index", "x-bergamot-sentence-score",
+                                    "x-bergamot-word-index", "x-bergamot-word-score",
+                                ]);
+
+                                if (node.nodeType === Node.ELEMENT_NODE) {
+                                    if (node.nodeName !== "FONT") return false;
+
+                                    if (!node.getAttributeNames().every(attribute => allowed.has(attribute))) return false;
+
+                                    for (let child of node.childNodes) if (!hasOnlyQEAttributes(child)) return false;
+                                }
+                                return true;
+                            };
+
                             /*
                              * if translated element child doesn't have data-x-bergamot-id attribute and
-                             * has quality score specific attributes (that are set by translation engine
+                             * has only quality score specific attributes (that are set by translation engine
                              * when QE is on) then just add the translated element child to the live
                              * element node.
                              */
-                            if (!child.hasAttribute("data-x-bergamot-id") && (child.hasAttribute("x-bergamot-sentence-index") || child.hasAttribute("x-bergamot-word-index"))) {
+                            if (!child.hasAttribute("data-x-bergamot-id") && hasOnlyQEAttributes(child)) {
                                 dst.appendChild(child);
                             } else {
                                 console.warn(`[InPlaceTranslation] ${this.computePath(child, scratch)} Could not find counterpart for`, child.dataset.xBergamotId, dstChildNodes, child);


### PR DESCRIPTION
Fixes https://github.com/mozilla/firefox-translations/issues/267

 - Sanitize the qe specific html text that is added to DOM via `appendChild`
 - Using DocumentFragment to update DOM instead of setting innerHTML directly
 
 cc @Rob--W