### PR TITLE
Remove cachebuster and ChromeUtils.import: remove second {} parameter; not needed and deprecated

### DIFF
--- a/extension/controller/experiments/TelemetryEnvironment/api.js
+++ b/extension/controller/experiments/TelemetryEnvironment/api.js
@@ -11,14 +11,8 @@
 // eslint-disable-next-line no-invalid-this
 this.experiment_telemetryEnvironment = class extends ExtensionAPI {
   getAPI() {
-    const { TelemetryController } = ChromeUtils.import(
-      "resource://gre/modules/TelemetryController.jsm",
-      {},
-    );
-    const { TelemetryEnvironment } = ChromeUtils.import(
-      "resource://gre/modules/TelemetryEnvironment.jsm",
-      {},
-    );
+    const { TelemetryController } = ChromeUtils.import("resource://gre/modules/TelemetryController.jsm");
+    const { TelemetryEnvironment } = ChromeUtils.import("resource://gre/modules/TelemetryEnvironment.jsm");
 
     const collectTelemetryEnvironment = () => {
       const environment = TelemetryEnvironment.currentEnvironment;

--- a/extension/controller/experiments/TranslationBar/api.js
+++ b/extension/controller/experiments/TranslationBar/api.js
@@ -21,9 +21,9 @@
       // map responsible holding the TranslationNotificationManager per tabid
       const translationNotificationManagers = new Map();
 
-      Services.scriptloader.loadSubScript(`${context.extension.getURL("/view/js/TranslationNotificationManager.js",)}?cachebuster=${Date.now()}`
+      Services.scriptloader.loadSubScript(`${context.extension.getURL("/view/js/TranslationNotificationManager.js",)}`
       ,);
-      Services.scriptloader.loadSubScript(`${context.extension.getURL("/model/modelRegistry.js",)}?cachebuster=${Date.now()}`
+      Services.scriptloader.loadSubScript(`${context.extension.getURL("/model/modelRegistry.js",)}`
       ,);
 
       /*
@@ -65,19 +65,12 @@
                   return;
                 }
 
-                /*
-                 * as a workaround to be able to load updates for the translation notification on extension reload
-                 * we use the current unix timestamp as part of the element id.
-                 * TODO: Restrict use of Date.now() as cachebuster to development mode only
-                 */
                 chromeWin.now = Date.now();
                 chromeWin.customElements.setElementCreationCallback(
                   `translation-notification-${chromeWin.now}`,
                   () => {
                     Services.scriptloader.loadSubScript(
-                      `${context.extension.getURL("view/js/translation-notification-fxtranslations.js",)
-                        }?cachebuster=${
-                        chromeWin.now}`,
+                      `${context.extension.getURL("view/js/translation-notification-fxtranslations.js",)}`,
                       chromeWin,
                     );
 

--- a/extension/controller/experiments/TranslationBar/api.js
+++ b/extension/controller/experiments/TranslationBar/api.js
@@ -11,21 +11,12 @@
  this.experiments_translationbar = class extends ExtensionAPI {
     getAPI(context) {
 
-      const { ExtensionUtils } = ChromeUtils.import(
-        "resource://gre/modules/ExtensionUtils.jsm",
-        {},
-      );
+      const { ExtensionUtils } = ChromeUtils.import("resource://gre/modules/ExtensionUtils.jsm");
       const { ExtensionError } = ExtensionUtils;
 
-      const { Services } = ChromeUtils.import(
-        "resource://gre/modules/Services.jsm",
-        {},
-      );
+      const { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
 
-      const { ExtensionCommon } = ChromeUtils.import(
-        "resource://gre/modules/ExtensionCommon.jsm",
-        {},
-      );
+      const { ExtensionCommon } = ChromeUtils.import("resource://gre/modules/ExtensionCommon.jsm");
 
       // map responsible holding the TranslationNotificationManager per tabid
       const translationNotificationManagers = new Map();
@@ -126,10 +117,7 @@
               translatonNotificationManager.notificationBox.updateTranslationProgress(progressMessage);
             },
             switchOnPreferences: function switchOnPreferences() {
-               const { Services } = ChromeUtils.import(
-                 "resource://gre/modules/Services.jsm",
-                 {},
-               );
+               const { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
                Services.prefs.setBoolPref("browser.translation.ui.show", false);
                Services.prefs.setBoolPref("extensions.translations.disabled", false);
                Services.prefs.setBoolPref("browser.translation.detectLanguage",false,);


### PR DESCRIPTION
Fixes #276 