### PR TITLE
Reliable TranslationBar lifetime management + cleanup

### DIFF
--- a/extension/controller/backgroundScript.js
+++ b/extension/controller/backgroundScript.js
@@ -212,16 +212,6 @@ const messageListener = function(message, sender) {
             );
             break;
         case "recordTelemetry":
-
-          /*
-           * if the event was to close the infobar, we notify the api as well
-           * we don't need another redundant loop by informing the mediator,
-           * to then inform this script again
-           */
-          if (message.name === "closed") {
-            browser.experiments.translationbar.closeInfobar(message.tabId);
-          }
-
           getTelemetry(message.tabId).record(message.type, message.category, message.name, message.value);
           break;
 
@@ -303,9 +293,6 @@ const messageListener = function(message, sender) {
               tabId: message.tabId
             }
           );
-          break;
-        case "reportClosedInfobar":
-          browser.experiments.translationbar.closeInfobar(message.tabId);
           break;
         case "setStorage":
           await browser.storage.local.set(message.payload)

--- a/extension/controller/experiments/TranslationBar/schema.json
+++ b/extension/controller/experiments/TranslationBar/schema.json
@@ -82,19 +82,6 @@
                 "description": "language code"
             }
           ]
-        },
-        {
-          "name": "closeInfobar",
-          "type": "function",
-          "description": "Reports the user closed the infobar.",
-          "async": true,
-          "parameters": [
-            {
-                "name": "tabId",
-                "type": "integer",
-                "description": "tabId to host the translation bar"
-            }
-          ]
         }
       ],
       "events": [

--- a/extension/mediator.js
+++ b/extension/mediator.js
@@ -112,7 +112,6 @@ class Mediator {
                  * it is recommended to use visibilitychange event for this use case,
                  * but it triggers some errors because of communication with bgScript, so let's use beforeunload for now
                  */
-                browser.runtime.sendMessage({ command: "reportClosedInfobar", tabId: this.tabId });
                 browser.runtime.sendMessage({ command: "submitPing", tabId: this.tabId });
             });
 


### PR DESCRIPTION
- Remove TranslationBars on extension shutdown, instead of littering the user's browser with unusable bars after the extension was disabled.

- Use the notification's eventCallback to manage TranslationBars in a reliable way. This supersedes the following old logic:

  - backgroundScript:recordTelemetry used to handle the closeCommand caller in translation-notification-fxtranslations.js.

  - backgroundScript:reportClosedInfobar used to handle the beforeunload caller from mediator.js. This was unreliable and caused #275.

Fixes #275