### PR TITLE
fix browser_translation_test.js failure after #293

### DIFF
--- a/scripts/tests/browser_translation_test.js
+++ b/scripts/tests/browser_translation_test.js
@@ -153,7 +153,7 @@ add_task(async function testTranslationBarDisplayed() {
   });
 
   delete window.MozTranslationNotification;
-  delete window.now;
+  delete window.TRANSLATION_NOTIFICATION_ELEMENT_ID;
   notification.close();
   BrowserTestUtils.removeTab(tab);
 });


### PR DESCRIPTION
In PR #293 I removed the use of `window.now`, and introduced `window.TRANSLATION_NOTIFICATION_ELEMENT_ID`.

The test deleted the old one but not the new one, which caused the following failure:

```

Unexpected Results
------------------
browser/extensions/translations/test/browser/browser_translation_test.js
  FAIL test left unexpected property on window: TRANSLATION_NOTIFICATION_ELEMENT_ID -
```