### PR TITLE
Clarify shared state of LanguageDetection

### DIFF
--- a/extension/controller/languageDetection/LanguageDetection.js
+++ b/extension/controller/languageDetection/LanguageDetection.js
@@ -13,11 +13,23 @@ class LanguageDetection {
             this.constructLanguageSets();
         this.navigatorLanguage = this.getNavigatorLanguage();
         this.pageLanguage = null;
-        this.wordsToDetect = null;
     }
 
     extractPageContent() {
-        this.wordsToDetect = document.body.innerText;
+        let supported = this.isBrowserSupported();
+        // skip (expensive) page content extraction if not supported
+        let wordsToDetect =
+            supported
+            ? document.body.innerText
+            : "";
+        return { supported, wordsToDetect };
+    }
+
+    /*
+     * update the page language used for detection.
+     */
+    setPageLanguage(pageLanguage) {
+        this.pageLanguage = pageLanguage;
     }
 
     /*

--- a/extension/mediator.js
+++ b/extension/mediator.js
@@ -53,8 +53,6 @@ class Mediator {
 
         if (!this.isStarted && this.isMainFrame) {
             this.isStarted = true;
-            // request the language detection class to extract a page's snippet
-            this.languageDetection.extractPageContent();
 
             /*
              * request the background script to detect the page's language and
@@ -62,7 +60,7 @@ class Mediator {
              */
             browser.runtime.sendMessage({
                 command: "detectPageLanguage",
-                languageDetection: this.languageDetection
+                languageDetection: this.languageDetection.extractPageContent(),
             })
         }
     }
@@ -313,7 +311,7 @@ class Mediator {
                     this.start(message.tabId, message.platformInfo);
                     break;
                 case "responseDetectPageLanguage":
-                    this.languageDetection = Object.assign(new LanguageDetection(), message.languageDetection);
+                    this.languageDetection.setPageLanguage(message.pageLanguage);
                     if (this.isMainFrame) this.determineIfTranslationisRequired();
                     break;
                 case "translationRequested":
@@ -326,7 +324,7 @@ class Mediator {
                      */
 
                     // the user might have changed the page language, so we just accept it
-                    this.languageDetection.pageLanguage = message.from;
+                    this.languageDetection.setPageLanguage(message.from);
                     if (!this.inPageTranslation.started) {
                         this.inPageTranslation.withOutboundTranslation = message.withOutboundTranslation;
                         this.inPageTranslation.withQualityEstimation = message.withQualityEstimation;


### PR DESCRIPTION
- Remove global `LanguageDetection` instance from backgroundScript.js, so that it is obvious that the `pageAction.onClicked` listener does not depend on any tab-specific state (#296).

- Minimize the amount of data (i.e. wordsToDetect) that is being passed back and forth, to only when needed (#284).

Fixes #284
Fixes #296