### PR TITLE
Removed translation worker from content script list

### DIFF
--- a/extension/controller/translation/translationWorker.js
+++ b/extension/controller/translation/translationWorker.js
@@ -138,14 +138,17 @@ class TranslationHelper {
                              * messages. Therefore, always encode and pass source messages as HTML to the
                              * engine and restore them afterwards to their original form.
                              */
+                            const escapeHtml = text => {
+                                return String(text).replace(/&/g, '&amp;')
+                                .replace(/"/g, '&quot;').replace(/'/g, '&#039;')
+                                .replace(/</g, '&lt;').replace(/>/g, '&gt;');
+                            };
                             const non_html_qe_messages = new Map();
                             translationMessagesBatch.forEach((message, index) => {
                                 if (message.withQualityEstimation && !message.isHTML) {
                                     console.log(`Plain text received to translate with QE: "${message.sourceParagraph}"`);
                                     non_html_qe_messages.set(index, message.sourceParagraph);
-                                    const div = document.createElement("div");
-                                    div.appendChild(document.createTextNode(message.sourceParagraph));
-                                    message.sourceParagraph = div.innerHTML;
+                                    message.sourceParagraph = escapeHtml(message.sourceParagraph);
                                     message.isHTML = true;
                                 }
                             });

--- a/extension/controller/translation/translationWorker.js
+++ b/extension/controller/translation/translationWorker.js
@@ -16,7 +16,7 @@ let engineWasmLocalPath;
  */
 class TranslationHelper {
 
-        constructor(postMessage) {
+        constructor() {
             // all variables specific to translation service
             this.translationService = null;
             this.responseOptions = null;
@@ -24,7 +24,6 @@ class TranslationHelper {
             // a map of language-pair to TranslationModel object
             this.translationModels = new Map();
             this.CACHE_NAME = "fxtranslations";
-            this.postMessage = postMessage;
             this.wasmModuleStartTimestamp = null;
             this.WasmEngineModule = null;
             this.engineState = this.ENGINE_STATE.LOAD_PENDING;
@@ -698,7 +697,7 @@ class TranslationHelper {
         }
 }
 
-const translationHelper = new TranslationHelper(postMessage);
+const translationHelper = new TranslationHelper();
 onmessage = function(message) {
     switch (message.data[0]) {
         case "configEngine":

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -48,7 +48,6 @@
       "js": [
         "model/Queue.js",
         "controller/translation/TranslationMessage.js",
-        "controller/translation/translationWorker.js",
         "controller/translation/Translation.js"
       ],
       "all_frames": false,


### PR DESCRIPTION
Fixes https://github.com/mozilla/firefox-translations/issues/274

- Removed `this.postMessage` as per recommendation from https://github.com/mozilla/firefox-translations/issues/274#issuecomment-1114828079
- Removed `translationWorker.js` file from content scripts in `manifest.json`
- Removed references to `document` in worker file and added an html escaping function