### PR TITLE
Clean web-accessible resources from manifest.json

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -82,9 +82,6 @@
 
   ],
   "web_accessible_resources": [
-    "view/static/outboundTranslation.html",
-    "view/static/dataConsent.html",
-    "model/Queue.js",
     "controller/translation/translationWorker.js"
   ],
   "incognito": "spanning",


### PR DESCRIPTION
This was as clean we could get before starting breaking it.

fixes #313