### PR TITLE
Add metadata to survey link

### DIFF
--- a/extension/controller/backgroundScript.js
+++ b/extension/controller/backgroundScript.js
@@ -11,6 +11,7 @@ modelRegistryRootURL, modelRegistryRootURLTest, modelRegistry */
  * extension's background process.
  */
 
+const extensionVersion = browser.runtime.getManifest().version;
 const scrubSentryEvent = ev => {
 
   /*
@@ -40,7 +41,7 @@ const initializeSentry = () => {
     dsn: settings.sentryDsn,
     tracesSampleRate: 1.0,
     debug: settings.sentryDebug,
-    release: `firefox-translations@${browser.runtime.getManifest().version}`,
+    release: `firefox-translations@${extensionVersion}`,
     beforeSend: scrubSentryEvent,
     integrations(integrations) {
       // integrations will be all default integrations
@@ -90,7 +91,7 @@ const getTelemetry = tabId => {
     if (!telemetryByTab.has(tabId)) {
         let telemetry = new Telemetry(pingSender);
         telemetryByTab.set(tabId, telemetry);
-        telemetry.versions(browser.runtime.getManifest().version, "?", BERGAMOT_VERSION_FULL);
+      telemetry.versions(extensionVersion, "?", BERGAMOT_VERSION_FULL);
         if (cachedEnvInfo) {
             telemetry.environment(cachedEnvInfo);
         }
@@ -246,7 +247,8 @@ const messageListener = function(message, sender) {
           ).catch(onError);
           break;
         case "showSurvey":
-          browser.tabs.create({ url: "https://qsurvey.mozilla.com/s3/Firefox-Translations" });
+          browser.tabs.create({ url:
+              `https://qsurvey.mozilla.com/s3/Firefox-Translations?version=${extensionVersion}&from_lang=${message.from}&to_lang=${message.to}` });
           break;
         case "translationComplete":
           if (!await isFrameLoaded(sender.tab.id, message.translationMessage.frameId)) return;

--- a/extension/view/js/TranslationNotificationManager.js
+++ b/extension/view/js/TranslationNotificationManager.js
@@ -118,12 +118,12 @@ class TranslationNotificationManager {
         this.bgScriptListenerCallback(message);
     }
 
-    showSurvey() {
+    showSurvey(from, to) {
 
         /*
          * notify the mediator that the user wants to participate in survey
          */
-        const message = { command: "showSurvey", tabId: this.tabId };
+        const message = { command: "showSurvey", tabId: this.tabId, from, to };
         this.bgScriptListenerCallback(message);
     }
 

--- a/extension/view/js/translation-notification-fxtranslations.js
+++ b/extension/view/js/translation-notification-fxtranslations.js
@@ -242,7 +242,9 @@ window.MozTranslationNotification = class extends MozElements.Notification {
   }
 
   onSurveyClick() {
-    this.translationNotificationManager.showSurvey();
+    const from = this._getSourceLang();
+    const to = this._getTargetLang();
+    this.translationNotificationManager.showSurvey(from, to);
   }
 
   /*


### PR DESCRIPTION
Added:
- extension version
- source language of last translation
- target language of last translation

This will help us to understand what version the feedback applies to and what language pairs a user translated last if there are complaints about translation quality.

fixes #352 