### PR TITLE
Restrict minimum version to what's compatible with the wasm engine and report errors compiling

### DIFF
--- a/extension/controller/experiments/TranslationBar/api.js
+++ b/extension/controller/experiments/TranslationBar/api.js
@@ -7,12 +7,6 @@
 
 /* global ExtensionCommon, ExtensionAPI, ChromeUtils, Services, modelRegistry, TranslationNotificationManager  */
 
-// the Services object was not available until Firefox 88 - bugzil.la/1698158
-if (typeof Services === "undefined") {
-  // eslint-disable-next-line no-invalid-this
-  this.Services = ChromeUtils.import("resource://gre/modules/Services.jsm").Services;
-}
-
 /*
  * custom elements can only be registered, and not unregistered.
  * To make sure that the extension is able to register the custom element

--- a/extension/controller/translation/translationWorker.js
+++ b/extension/controller/translation/translationWorker.js
@@ -66,6 +66,12 @@ class TranslationHelper {
                         this.wasmModuleStartTimestamp = Date.now();
                     }.bind(this)
                 ],
+                onAbort() {
+                    sendException(new Error("Error loading engine (onAbort)"));
+                    console.log("Error loading wasm module.");
+                    postMessage(["reportError", "engine_load"]);
+                    postMessage(["updateProgress", "errorLoadingWasm"]);
+                },
                 onRuntimeInitialized: function() {
 
                     /*

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -7,13 +7,13 @@
   "applications": {
     "gecko": {
       "id": "firefox-translations-addon@mozilla.org",
-      "strict_min_version": "79.0"
+      "strict_min_version": "90.0"
     }
   },
   "browser_specific_settings": {
     "gecko": {
       "id": "firefox-translations-addon@mozilla.org",
-      "strict_min_version": "79.0"
+      "strict_min_version": "90.0"
     }
   },
   "options_ui": {


### PR DESCRIPTION
@abhi-agg I found that this error happens not only on processors without SSE4.1, but also on Fx versions earlier than 90. 

fixes #370 