### PR TITLE
Default value for getBoolPref API for fxtranslations.running.mochitest

### DIFF
--- a/extension/controller/experiments/TranslationBar/api.js
+++ b/extension/controller/experiments/TranslationBar/api.js
@@ -191,7 +191,7 @@ const translationNotificationManagers = new Map();
               return Services.intl.getLanguageDisplayNames(undefined, [languageCode,])[0];
             },
             isMochitest: function isMochitest() {
-              const isMochitest = Services.prefs.getBoolPref("fxtranslations.running.mochitest");
+              const isMochitest = Services.prefs.getBoolPref("fxtranslations.running.mochitest", false);
               return isMochitest;
             },
            onTranslationRequest: new ExtensionCommon.EventManager({


### PR DESCRIPTION
Fixes https://github.com/mozilla/firefox-translations/issues/393