### PR TITLE
Browse directly to Firefox Translations section on about:preferences when clicking on Options -> Translation Preferences

### DIFF
--- a/extension/view/js/translation-notification-fxtranslations.js
+++ b/extension/view/js/translation-notification-fxtranslations.js
@@ -40,7 +40,7 @@ window.MozTranslationNotification = class extends MozElements.Notification {
             <menuitem anonid="neverForLanguage" oncommand="this.closest('notification').neverForLanguage();"/>
             <menuitem anonid="neverForSite" oncommand="this.closest('notification').neverForSite();" label="&translation.options.neverForSite.label;" accesskey="&translation.options.neverForSite.accesskey;"/>
             <menuseparator/>
-            <menuitem oncommand="openPreferences('paneGeneral');" label="&translation.options.preferences.label;" accesskey="&translation.options.preferences.accesskey;"/>
+            <menuitem oncommand="openPreferences('paneGeneral-fxtranslations');" label="&translation.options.preferences.label;" accesskey="&translation.options.preferences.accesskey;"/>
             <menuseparator/>
             <menuitem anonid="displayStatistics" oncommand="this.closest('notification').displayStatistics();" label=""/>
             </menupopup>


### PR DESCRIPTION
fixes #319 

along https://phabricator.services.mozilla.com/D150446