### PR TITLE
Disable statistics instead of the options button after translation has started

### DIFF
--- a/extension/view/js/translation-notification-fxtranslations.js
+++ b/extension/view/js/translation-notification-fxtranslations.js
@@ -193,7 +193,7 @@ window.MozTranslationNotification = class extends MozElements.Notification {
     );
     this.state = this.translationNotificationManager.TranslationInfoBarStates.STATE_TRANSLATING;
     this._getAnonElt("closeButton").disabled = true;
-    this._getAnonElt("options").disabled = true;
+    this._getAnonElt("displayStatistics").style.display = "none";
     this._getAnonElt("aftertranslatedOptions").style.display = "block";
   }
 


### PR DESCRIPTION
fixes #321 