### PR TITLE
Explicitly provide a charset on the changelog

### DIFF
--- a/extension/view/static/CHANGELOG.html
+++ b/extension/view/static/CHANGELOG.html
@@ -1,10 +1,11 @@
+<meta charset="UTF-8">
 <style>
 body {
 	background-color: lightgrey;
     font-family:system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
 }
 </style>
-<img src="../icons/translation-color.svg" style="width: 5rem";><h1>Firefox Translations Changelog</h1>
+<img src="../icons/translation-color.svg" style="width: 5rem;"><h1>Firefox Translations Changelog</h1>
 
 <p>Firefox Translations is a webextension developed by Mozilla that enables client side in-page translation for Firefox.</p>
 

--- a/scripts/changelog.tpl
+++ b/scripts/changelog.tpl
@@ -1,7 +1,8 @@
+<meta charset="UTF-8">
 <style>
 body {
 	background-color: lightgrey;
     font-family:system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
 }
 </style>
-<img src="../icons/translation-color.svg" style="width: 5rem";>
+<img src="../icons/translation-color.svg" style="width: 5rem;">


### PR DESCRIPTION
Hopefully fix #463.

Also move the loose semicolon in the `img` tag inside `style`, where I think it was supposed to be.