### PR TITLE
Normalize language codes used in webpages when judging nodes to exclude

### DIFF
--- a/extension/view/js/InPageTranslation.js
+++ b/extension/view/js/InPageTranslation.js
@@ -227,6 +227,10 @@ class InPageTranslation {
         /*
          * pre-construct the excluded node selector. Doing it here since it
          * needs to know `language`. See `containsExcludedNode()`.
+         * Note: [lang]:not([lang...]) is too strict as it also matches slightly
+         * different language code. In that case the tree walker will drill down
+         * and still accept the element in isExcludedNode. Just not as part of
+         * a block.
          */
         this.excludedNodeSelector = `[lang]:not([lang|="${this.language}"]),[translate=no],.notranslate,[contenteditable],${Array.from(this.excludedTags).join(",")},#OTapp`;
 
@@ -524,9 +528,14 @@ class InPageTranslation {
 
         /*
          * exclude elements that have a lang attribute that mismatches the
-         * language we're currently translating.
+         * language we're currently translating. Run it through
+         * getCanonicalLocales() because pages get creative.
          */
-        if (node.lang && node.lang.substr(0,2) !== this.language) return true;
+        try {
+            if (node.lang && !Intl.getCanonicalLocales(node.lang).some(lang => this.isSameLanguage(lang, this.language))) return true;
+        } catch (err) {
+            if (err.name !== "RangeError") throw err;
+        }
 
         /*
          * exclude elements that have an translate=no attribute
@@ -1027,5 +1036,23 @@ class InPageTranslation {
                     break;
             }
         });
+    }
+
+    isSameLanguage(lang, other) {
+        /**
+         * en === en, en-US === en-US
+         */
+        if (lang === other) return true;
+
+        /*
+         * en-US === en
+         */
+        if (lang.includes("-") && !other.includes("-") && lang.split("-")[0] === other) return true;
+
+        /*
+         * intentionally not testing for en === en-US to make sure very
+         * specific models are not used for translating broad language codes.
+         */
+        return false;
     }
 }

--- a/extension/view/js/InPageTranslation.js
+++ b/extension/view/js/InPageTranslation.js
@@ -1039,6 +1039,7 @@ class InPageTranslation {
     }
 
     isSameLanguage(lang, other) {
+
         /*
          * en === en, en-US === en-US
          */

--- a/extension/view/js/InPageTranslation.js
+++ b/extension/view/js/InPageTranslation.js
@@ -1039,7 +1039,7 @@ class InPageTranslation {
     }
 
     isSameLanguage(lang, other) {
-        /**
+        /*
          * en === en, en-US === en-US
          */
         if (lang === other) return true;


### PR DESCRIPTION
Found on a page exported from Word, which added `lang="CS"` to every element. Which then did not match `this.language === "cs"` so it excluded all nodes from translation.

This fixes that by using `Intl.getCanonicalLocales()` which normalises case, but also things like using `fra` for `fr`. If it doesn't understand the language code in `lang=""`, it will just skip this check. It assumes that `this.language` is already normalised. But since that comes straight from the model register, I think that's a safe assumption.

I changed the checks slightly. So `en-US` will be translated by a model that targets `en`, but not a model that specifically targets `en-GB`. Not that we would have such a thing, but for zh I could imagine having more specific models.