### PR TITLE
Add option to disable changelog

### DIFF
--- a/extension/view/static/dataConsent.html
+++ b/extension/view/static/dataConsent.html
@@ -121,6 +121,15 @@ input:checked + .slider::before {
       </label>
     </div>
   </div>
+  <div class="maindiv">
+    <div class="item flex">
+      <div class="divlabel" id="lblShowChangelog"></div>
+      <label class="switch">
+          <input type="checkbox" id="showChangelog">
+          <span class="slider round"></span>
+      </label>
+    </div>
+  </div>
 <script src="dataConsent.js"></script>
 </body>
 </html>

--- a/extension/view/static/dataConsent.js
+++ b/extension/view/static/dataConsent.js
@@ -33,3 +33,6 @@ document.getElementById("lblReportUserInteraction").textContent =
 
 document.getElementById("lblErrorReport").textContent =
 browser.i18n.getMessage("datacollectionConsentPageErrorsOption");
+
+document.getElementById("lblShowChangelog").textContent =
+  browser.i18n.getMessage("showChangelogOption");


### PR DESCRIPTION
Users toggle the option on the addon's option page. The option is off by default.

I'm not sure if the `dataConsent.html` page should be renamed to something like `options.html` since it no longer conatains _only_ data-consent options.

Fixes #483.

For translations see mozilla-l10n/firefox-translations-l10n#15.