### PR TITLE
Bug 1794817 - Fix showing "translate as you browse" button.

### DIFF
--- a/extension/view/js/translation-notification-fxtranslations.js
+++ b/extension/view/js/translation-notification-fxtranslations.js
@@ -166,7 +166,7 @@ window.MozTranslationNotification = class extends MozElements.Notification {
     this._getAnonElt("outboundtranslations-check").style.display = "none";
     this._getAnonElt("qualityestimations-check").style.display = "none";
     this._getAnonElt("translate").style.display = "none";
-    this._getAnonElt("translateAsBrowse").style.display = "inline";
+    this._getAnonElt("translateAsBrowse").style.display = "";
     this.updateTranslationProgress("");
   }
 


### PR DESCRIPTION
This fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1794817.

display: inline didn't use to get honored before bug 1790920 (it ended up being equivalent to display: -moz-inline-box). Since the only thing we want is to remove the display: none in the style attribute, do that instead, letting the default display work.