### PR TITLE
Remove redundant padding declaration

### DIFF
--- a/extension/view/popup/css/index.css
+++ b/extension/view/popup/css/index.css
@@ -92,7 +92,6 @@ button {
   border: 1px solid #88c;
   border-radius: 4px;
   background: #eef;
-  padding: 0;
   padding: 0.25rem 0.5rem;
 }
 button:hover {


### PR DESCRIPTION
The property is overwritten by the immediately proceeding declaration.