### PR TITLE
Remove redundant class declaration

### DIFF
--- a/extension/view/popup/index.html
+++ b/extension/view/popup/index.html
@@ -16,7 +16,7 @@
           <select id="lang-from" name="from" class="lang-select"></select>
         </label>
         <textarea id="input" name="input" autofocus></textarea>
-        <div id="suggestion" class="suggestion"><div id="translatefrom"></div> <div id="translatelanguage"></div></div>
+        <div id="suggestion"><div id="translatefrom"></div> <div id="translatelanguage"></div></div>
       </div>
       <button class="swap" title="swap">↔️</button>
       <div class="panel panel--to">


### PR DESCRIPTION
The class is never used as a selector or queried for in JS, nor is it adding any extra information as the class name is identical to that of the `id`.