### PR TITLE
Use the same font-family throughout popup

### DIFF
--- a/extension/view/popup/css/index.css
+++ b/extension/view/popup/css/index.css
@@ -76,7 +76,6 @@ label {
 
 textarea {
   padding: 1rem;
-  font-family: sans-serif;
   font-size: 1rem;
   resize: none;
   border-radius: 2px;


### PR DESCRIPTION
It looks and feels more consistent using the same font for the textarea as with the rest of the popup.