### PR TITLE
Remove redundant declaration

### DIFF
--- a/extension/view/popup/css/index.css
+++ b/extension/view/popup/css/index.css
@@ -53,7 +53,6 @@ label {
   align-self: center;
   grid-area: swap;
   font-size: 1.1rem;
-  cursor: pointer;
 }
 
 #status {


### PR DESCRIPTION
`cursor: pointer` is inherited from the `button` ruleset in the same file.