### PR TITLE
Remove body wrapper

### DIFF
--- a/extension/view/popup/css/index.css
+++ b/extension/view/popup/css/index.css
@@ -6,15 +6,14 @@
   color-scheme: light dark;
 }
 
-html,
-body {
-  height: 100%;
-  margin: 0;
+html {
   font-size: 16px;
   font-family: Optima, Helvetica, Arial;
 }
 
-.app {
+body {
+  height: 100%;
+  margin: 0;
   padding: 1rem;
   display: grid;
   grid: "from swap to" 1fr "status status status" auto / 1fr auto 1fr;

--- a/extension/view/popup/index.html
+++ b/extension/view/popup/index.html
@@ -10,23 +10,21 @@
     />
   </head>
   <body>
-    <div class="app">
-      <div class="panel panel--from">
-        <label>
-          <select id="lang-from" name="from" class="lang-select"></select>
-        </label>
-        <textarea id="input" name="input" autofocus></textarea>
-        <div id="suggestion"><span id="translatefrom"></span> <span id="translatelanguage"></span></div>
-      </div>
-      <button class="swap" title="swap">↔️</button>
-      <div class="panel panel--to">
-        <label>
-          <select id="lang-to" name="to" class="lang-select"></select>
-        </label>
-        <textarea id="output" name="output" readonly></textarea>
-      </div>
-      <div class="footer" id="status"></div>
-    </div>
+		<div class="panel panel--from">
+			<label>
+				<select id="lang-from" name="from" class="lang-select"></select>
+			</label>
+			<textarea id="input" name="input" autofocus></textarea>
+			<div id="suggestion"><span id="translatefrom"></span> <span id="translatelanguage"></span></div>
+		</div>
+		<button class="swap" title="swap">↔️</button>
+		<div class="panel panel--to">
+			<label>
+				<select id="lang-to" name="to" class="lang-select"></select>
+			</label>
+			<textarea id="output" name="output" readonly></textarea>
+		</div>
+		<div class="footer" id="status"></div>
     <script src="/controller/translation/TranslationMessage.js"></script>
     <script src="/model/Queue.js"></script>
     <script src="/model/contentErrors.js"></script>

--- a/extension/view/popup/index.html
+++ b/extension/view/popup/index.html
@@ -10,21 +10,21 @@
     />
   </head>
   <body>
-		<div class="panel panel--from">
-			<label>
-				<select id="lang-from" name="from" class="lang-select"></select>
-			</label>
-			<textarea id="input" name="input" autofocus></textarea>
-			<div id="suggestion"><span id="translatefrom"></span> <span id="translatelanguage"></span></div>
-		</div>
-		<button class="swap" title="swap">↔️</button>
-		<div class="panel panel--to">
-			<label>
-				<select id="lang-to" name="to" class="lang-select"></select>
-			</label>
-			<textarea id="output" name="output" readonly></textarea>
-		</div>
-		<div class="footer" id="status"></div>
+      <div class="panel panel--from">
+        <label>
+          <select id="lang-from" name="from" class="lang-select"></select>
+        </label>
+        <textarea id="input" name="input" autofocus></textarea>
+        <div id="suggestion"><span id="translatefrom"></span> <span id="translatelanguage"></span></div>
+      </div>
+      <button class="swap" title="swap">↔️</button>
+      <div class="panel panel--to">
+        <label>
+          <select id="lang-to" name="to" class="lang-select"></select>
+        </label>
+        <textarea id="output" name="output" readonly></textarea>
+      </div>
+      <div class="footer" id="status"></div>
     <script src="/controller/translation/TranslationMessage.js"></script>
     <script src="/model/Queue.js"></script>
     <script src="/model/contentErrors.js"></script>

--- a/extension/view/popup/js/index.js
+++ b/extension/view/popup/js/index.js
@@ -146,7 +146,7 @@ const translateCall = () => {
         // we just need this class if we are on android since on desktop we want the default popup size
         let matchMedia = window.matchMedia("screen and (max-width: 640px)");
         if (matchMedia.matches && info.os.toLowerCase() === "android") {
-            document.getElementsByClassName("app")[0].style.grid = "'from from' auto 'status swap' auto 'to to' auto / 1fr";
+            document.getElementsByTagName("body")[0].style.grid = "'from from' auto 'status swap' auto 'to to' auto / 1fr";
             document.getElementsByClassName("swap")[0].style.transform = "rotate(90deg)";
             document.querySelector("#input").style.height = "50vmin";
             document.querySelector("#output").style.height = "50vmin";


### PR DESCRIPTION
The `.app` is a redundant wrapper, as we can just style the `body` tag directly.

Tested on Android and Desktop.