### PR TITLE
Disable in-page translation functionality when the built-in version is enabled

### DIFF
--- a/extension/controller/experiments/TranslationBar/api.js
+++ b/extension/controller/experiments/TranslationBar/api.js
@@ -90,6 +90,9 @@ const translationNotificationManagers = new Map();
       return {
         experiments: {
           translationbar: {
+            isBuiltInEnabled: function isBuiltInEnabled() {
+              return Services.prefs.getBoolPref("browser.translations.enable", false);
+            },
             show: function show(tabId, detectedLanguage, navigatorLanguage, localizedLabels, pageActionRequest, infobarSettings, autoTranslate, otSupported) {
               try {
 

--- a/extension/controller/experiments/TranslationBar/schema.json
+++ b/extension/controller/experiments/TranslationBar/schema.json
@@ -3,6 +3,13 @@
       "namespace": "experiments.translationbar",
       "functions": [
         {
+          "name": "isBuiltInEnabled",
+          "type": "function",
+          "description": "Returns true if the built-in version is enabled.",
+          "async": true,
+          "parameters": []
+        },
+        {
           "name": "show",
           "type": "function",
           "description": "Displays the translation bar.",

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -145,7 +145,6 @@
     "96": "/view/icons/translation-color.svg"
   },
   "page_action": {
-    "show_matches": ["<all_urls>"],
     "browser_style": true,
     "default_icon": "view/icons/translation-bw.svg",
     "default_title": "Firefox Translations"

--- a/extension/view/js/AndroidUI.js
+++ b/extension/view/js/AndroidUI.js
@@ -79,6 +79,10 @@ class AndroidUI {
         return this.mapLangs.get(lng);
     }
 
+    isBuiltInEnabled() {
+        return false;
+    }
+
     isMochitest() {
         return false;
     }

--- a/scripts/manifest.json
+++ b/scripts/manifest.json
@@ -145,7 +145,6 @@
     "96": "/view/icons/translation-color.svg"
   },
   "page_action": {
-    "show_matches": ["<all_urls>"],
     "browser_style": true,
     "default_icon": "view/icons/translation-bw.svg",
     "default_title": "Firefox Translations"


### PR DESCRIPTION
The value of the pref is cached on purpose so we don't have to read it on every page load. The only downside is that users will have to restart Firefox for the pref change to take effect, but only few users twiddle with the prefs so it's really minor.